### PR TITLE
Use yellow trainer moveset engine

### DIFF
--- a/data/trainers/special_moves.asm
+++ b/data/trainers/special_moves.asm
@@ -5,74 +5,41 @@
 
 SpecialTrainerMoves:
 	db BUG_CATCHER, 15
-	db 2, 2, TACKLE
-	db 2, 3, STRING_SHOT
 	db 0
 
 	db YOUNGSTER, 14
-	db 1, 4, FISSURE
 	db 0
 
 	db BROCK, 1
-	db 2, 3, BIND
-	db 2, 4, BIDE
+	db 2, 3, BIDE
 	db 0
 
 	db MISTY, 1
-	db 2, 4, BUBBLEBEAM
+	db 2, 3, BUBBLEBEAM
 	db 0
 
 	db LT_SURGE, 1
-	db 1, 1, THUNDERBOLT
-	db 1, 2, MEGA_PUNCH
-	db 1, 3, MEGA_KICK
-	db 1, 4, GROWL
+	db 3, 3, THUNDERBOLT
 	db 0
 
 	db ERIKA, 1
-	db 1, 3, MEGA_DRAIN
-	db 2, 1, RAZOR_LEAF
-	db 3, 1, PETAL_DANCE
+	db 3, 3, MEGA_DRAIN
 	db 0
 
 	db KOGA, 1
-	db 1, 1, TOXIC
-	db 1, 2, TACKLE
-	db 2, 1, TOXIC
-	db 2, 3, SUPERSONIC
-	db 3, 1, TOXIC
-	db 3, 2, DOUBLE_EDGE
-	db 4, 1, LEECH_LIFE
-	db 4, 2, DOUBLE_TEAM
-	db 4, 3, PSYCHIC_M
-	db 4, 4, TOXIC
+	db 4, 3, TOXIC
 	db 0
 
 	db BLAINE, 1
-	db 1, 1, FLAMETHROWER
-	db 1, 4, CONFUSE_RAY
-	db 3, 1, FLAMETHROWER
-	db 3, 2, FIRE_BLAST
-	db 3, 3, REFLECT
+	db 4, 3, FIRE_BLAST
 	db 0
 
 	db SABRINA, 1
-	db 1, 1, FLASH
-	db 2, 1, KINESIS
-	db 2, 4, PSYWAVE
-	db 3, 1, PSYWAVE
+	db 4, 3, PSYWAVE
 	db 0
 
 	db GIOVANNI, 3
-	db 1, 3, FISSURE
-	db 2, 2, DOUBLE_TEAM
-	db 3, 1, EARTHQUAKE
-	db 3, 3, THUNDER
-	db 4, 1, EARTHQUAKE
-	db 4, 2, LEER
-	db 4, 3, THUNDER
-	db 5, 1, ROCK_SLIDE
-	db 5, 4, EARTHQUAKE
+	db 5, 3, EARTHQUAKE
 	db 0
 
 	db LORELEI, 1
@@ -127,34 +94,18 @@ SpecialTrainerMoves:
 	db 0
 
 	db RIVAL3, 1
-	db 1, 3, EARTHQUAKE
-	db 2, 4, KINESIS
-	db 3, 4, LEECH_SEED
-	db 4, 1, ICE_BEAM
-	db 5, 1, CONFUSE_RAY
-	db 5, 4, FIRE_SPIN
-	db 6, 3, QUICK_ATTACK
+	db 1, 3, SKY_ATTACK
+	db 6, 3, BLIZZARD
 	db 0
 
 	db RIVAL3, 2
-	db 1, 3, EARTHQUAKE
-	db 2, 4, KINESIS
-	db 3, 4, LEECH_SEED
-	db 4, 1, THUNDERBOLT
-	db 5, 1, ICE_BEAM
-	db 6, 2, REFLECT
-	db 6, 3, QUICK_ATTACK
+	db 1, 3, SKY_ATTACK
+	db 6, 3, MEGA_DRAIN
 	db 0
 
 	db RIVAL3, 3
-	db 1, 3, EARTHQUAKE
-	db 2, 4, KINESIS
-	db 3, 4, LEECH_SEED
-	db 4, 1, CONFUSE_RAY
-	db 4, 4, FIRE_SPIN
-	db 5, 1, THUNDERBOLT
-	db 6, 1, AURORA_BEAM
-	db 6, 3, QUICK_ATTACK
+	db 1, 3, SKY_ATTACK
+	db 6, 3, FIRE_BLAST
 	db 0
 
 	db -1 ; end

--- a/data/trainers/special_moves.asm
+++ b/data/trainers/special_moves.asm
@@ -1,25 +1,160 @@
-; unique moves for gym leaders
-; this is not automatic! you have to write the index you want to [wLoneAttackNo]
-; first. e.g., erika's script writes 4 to [wLoneAttackNo] to get mega drain,
-; the fourth entry in the list.
-LoneMoves:
-	; pokemon index, move to give nth pokemon
-	db 1, BIDE
-	db 1, BUBBLEBEAM
-	db 2, THUNDERBOLT
-	db 2, MEGA_DRAIN
-	db 3, TOXIC
-	db 3, PSYWAVE
-	db 3, FIRE_BLAST
-	db 4, FISSURE
+; Yellow entry format:
+;	db trainerclass, trainerid
+;	repeat { db partymon location, partymon move, move id }
+;	db 0
 
-; unique moves for elite 4
-; all trainers in this class are given this move automatically
-; (unrelated to LoneMoves)
-TeamMoves:
-	; trainer, move
-	db LORELEI, BLIZZARD
-	db BRUNO,   FISSURE
-	db AGATHA,  TOXIC
-	db LANCE,   BARRIER
+SpecialTrainerMoves:
+	db BUG_CATCHER, 15
+	db 2, 2, TACKLE
+	db 2, 3, STRING_SHOT
+	db 0
+
+	db YOUNGSTER, 14
+	db 1, 4, FISSURE
+	db 0
+
+	db BROCK, 1
+	db 2, 3, BIND
+	db 2, 4, BIDE
+	db 0
+
+	db MISTY, 1
+	db 2, 4, BUBBLEBEAM
+	db 0
+
+	db LT_SURGE, 1
+	db 1, 1, THUNDERBOLT
+	db 1, 2, MEGA_PUNCH
+	db 1, 3, MEGA_KICK
+	db 1, 4, GROWL
+	db 0
+
+	db ERIKA, 1
+	db 1, 3, MEGA_DRAIN
+	db 2, 1, RAZOR_LEAF
+	db 3, 1, PETAL_DANCE
+	db 0
+
+	db KOGA, 1
+	db 1, 1, TOXIC
+	db 1, 2, TACKLE
+	db 2, 1, TOXIC
+	db 2, 3, SUPERSONIC
+	db 3, 1, TOXIC
+	db 3, 2, DOUBLE_EDGE
+	db 4, 1, LEECH_LIFE
+	db 4, 2, DOUBLE_TEAM
+	db 4, 3, PSYCHIC_M
+	db 4, 4, TOXIC
+	db 0
+
+	db BLAINE, 1
+	db 1, 1, FLAMETHROWER
+	db 1, 4, CONFUSE_RAY
+	db 3, 1, FLAMETHROWER
+	db 3, 2, FIRE_BLAST
+	db 3, 3, REFLECT
+	db 0
+
+	db SABRINA, 1
+	db 1, 1, FLASH
+	db 2, 1, KINESIS
+	db 2, 4, PSYWAVE
+	db 3, 1, PSYWAVE
+	db 0
+
+	db GIOVANNI, 3
+	db 1, 3, FISSURE
+	db 2, 2, DOUBLE_TEAM
+	db 3, 1, EARTHQUAKE
+	db 3, 3, THUNDER
+	db 4, 1, EARTHQUAKE
+	db 4, 2, LEER
+	db 4, 3, THUNDER
+	db 5, 1, ROCK_SLIDE
+	db 5, 4, EARTHQUAKE
+	db 0
+
+	db LORELEI, 1
+	db 1, 1, BUBBLEBEAM
+	db 2, 3, ICE_BEAM
+	db 3, 1, PSYCHIC_M
+	db 3, 2, SURF
+	db 4, 3, LOVELY_KISS
+	db 5, 3, BLIZZARD
+	db 0
+
+	db BRUNO, 1
+	db 1, 1, ROCK_SLIDE
+	db 1, 2, SCREECH
+	db 1, 4, DIG
+	db 2, 3, FIRE_PUNCH
+	db 2, 4, DOUBLE_TEAM
+	db 3, 1, DOUBLE_KICK
+	db 3, 2, MEGA_KICK
+	db 3, 4, DOUBLE_TEAM
+	db 4, 1, ROCK_SLIDE
+	db 4, 2, SCREECH
+	db 4, 4, EARTHQUAKE
+	db 5, 2, KARATE_CHOP
+	db 5, 3, STRENGTH
+	db 0
+
+	db AGATHA, 1
+	db 1, 2, SUBSTITUTE
+	db 1, 3, LICK
+	db 1, 4, MEGA_DRAIN
+	db 2, 2, TOXIC
+	db 2, 4, LEECH_LIFE
+	db 3, 2, LICK
+	db 4, 1, WRAP
+	db 5, 2, PSYCHIC_M
+	db 0
+
+	db LANCE, 1
+	db 1, 1, DRAGON_RAGE
+	db 2, 1, THUNDER_WAVE
+	db 2, 3, THUNDERBOLT
+	db 3, 1, BUBBLEBEAM
+	db 3, 2, WRAP
+	db 3, 3, ICE_BEAM
+	db 4, 1, WING_ATTACK
+	db 4, 2, SWIFT
+	db 4, 3, FLY
+	db 5, 1, BLIZZARD
+	db 5, 2, FIRE_BLAST
+	db 5, 3, THUNDER
+	db 0
+
+	db RIVAL3, 1
+	db 1, 3, EARTHQUAKE
+	db 2, 4, KINESIS
+	db 3, 4, LEECH_SEED
+	db 4, 1, ICE_BEAM
+	db 5, 1, CONFUSE_RAY
+	db 5, 4, FIRE_SPIN
+	db 6, 3, QUICK_ATTACK
+	db 0
+
+	db RIVAL3, 2
+	db 1, 3, EARTHQUAKE
+	db 2, 4, KINESIS
+	db 3, 4, LEECH_SEED
+	db 4, 1, THUNDERBOLT
+	db 5, 1, ICE_BEAM
+	db 6, 2, REFLECT
+	db 6, 3, QUICK_ATTACK
+	db 0
+
+	db RIVAL3, 3
+	db 1, 3, EARTHQUAKE
+	db 2, 4, KINESIS
+	db 3, 4, LEECH_SEED
+	db 4, 1, CONFUSE_RAY
+	db 4, 4, FIRE_SPIN
+	db 5, 1, THUNDERBOLT
+	db 6, 1, AURORA_BEAM
+	db 6, 3, QUICK_ATTACK
+	db 0
+
 	db -1 ; end

--- a/engine/battle/read_trainer_party.asm
+++ b/engine/battle/read_trainer_party.asm
@@ -15,8 +15,8 @@ ReadTrainer:
 	ld [hl], a
 
 ; get the pointer to trainer data for this class
-	ld a, [wCurOpponent]
-	sub OPP_ID_OFFSET + 1 ; convert value from pokemon to trainer
+	ld a, [wTrainerClass] ; get trainer class
+	dec a
 	add a
 	ld hl, TrainerDataPointers
 	ld c, a
@@ -53,7 +53,7 @@ ReadTrainer:
 .LoopTrainerData
 	ld a, [hli]
 	and a ; have we reached the end of the trainer data?
-	jr z, .FinishUp
+	jp z, .AddAdditionalMoveData
 	ld [wcf91], a ; write species somewhere (XXX why?)
 	ld a, ENEMY_PARTY_DATA
 	ld [wMonDataLocation], a
@@ -68,7 +68,7 @@ ReadTrainer:
 ; - if [wLoneAttackNo] != 0, one pokemon on the team has a special move
 	ld a, [hli]
 	and a ; have we reached the end of the trainer data?
-	jr z, .AddLoneMove
+	jr z, .AddAdditionalMoveData
 	ld [wCurEnemyLVL], a
 	ld a, [hli]
 	ld [wcf91], a
@@ -78,69 +78,48 @@ ReadTrainer:
 	call AddPartyMon
 	pop hl
 	jr .SpecialTrainer
-.AddLoneMove
-; does the trainer have a single monster with a different move?
-	ld a, [wLoneAttackNo] ; Brock is 01, Misty is 02, Erika is 04, etc
-	and a
-	jr z, .AddTeamMove
-	dec a
-	add a
+.AddAdditionalMoveData
+; does the trainer have additional move data?
+	ld a, [wTrainerClass]
+	ld b, a
+	ld a, [wTrainerNo]
 	ld c, a
-	ld b, 0
-	ld hl, LoneMoves
-	add hl, bc
+	ld hl, SpecialTrainerMoves
+.loopAdditionalMoveData
 	ld a, [hli]
-	ld d, [hl]
-	ld hl, wEnemyMon1Moves + 2
+	cp $ff
+	jr z, .FinishUp
+	cp b
+	jr nz, .asm_39c46
+	ld a, [hli]
+	cp c
+	jr nz, .asm_39c46
+	ld d, h
+	ld e, l
+.writeAdditionalMoveDataLoop
+	ld a, [de]
+	inc de
+	and a
+	jp z, .FinishUp
+	dec a
+	ld hl, wEnemyMon1Moves
 	ld bc, wEnemyMon2 - wEnemyMon1
 	call AddNTimes
-	ld [hl], d
-	jr .FinishUp
-.AddTeamMove
-; check if our trainer's team has special moves
-
-; get trainer class number
-	ld a, [wCurOpponent]
-	sub OPP_ID_OFFSET
-	ld b, a
-	ld hl, TeamMoves
-
-; iterate through entries in TeamMoves, checking each for our trainer class
-.IterateTeamMoves
+	ld a, [de]
+	inc de
+	dec a
+	ld c, a
+	ld b, 0
+	add hl, bc
+	ld a, [de]
+	inc de
+	ld [hl], a
+	jr .writeAdditionalMoveDataLoop
+.asm_39c46
 	ld a, [hli]
-	cp b
-	jr z, .GiveTeamMoves ; is there a match?
-	inc hl ; if not, go to the next entry
-	inc a
-	jr nz, .IterateTeamMoves
-
-; no matches found. is this trainer champion rival?
-	ld a, b
-	cp RIVAL3
-	jr z, .ChampionRival
-	jr .FinishUp ; nope
-.GiveTeamMoves
-	ld a, [hl]
-	ld [wEnemyMon5Moves + 2], a
-	jr .FinishUp
-.ChampionRival ; give moves to his team
-
-; pidgeot
-	ld a, SKY_ATTACK
-	ld [wEnemyMon1Moves + 2], a
-
-; starter
-	ld a, [wRivalStarter]
-	cp STARTER3
-	ld b, MEGA_DRAIN
-	jr z, .GiveStarterMove
-	cp STARTER1
-	ld b, FIRE_BLAST
-	jr z, .GiveStarterMove
-	ld b, BLIZZARD ; must be squirtle
-.GiveStarterMove
-	ld a, b
-	ld [wEnemyMon6Moves + 2], a
+	and a
+	jr nz, .asm_39c46
+	jr .loopAdditionalMoveData
 .FinishUp
 ; clear wAmountMoneyWon addresses
 	xor a


### PR DESCRIPTION
This uses the yellow special move engine for trainer battles but keeps the original red/blue special moves for gym leaders and the rival champion. The elite four have their yellow movesets since they have the same pokemon and the movesets are better. This would not work well for Rival and gym leaders since their pokemon lists change.