### PR TITLE
Reintroduce MIssingno glitch using base stats

### DIFF
--- a/data/pokemon/base_stats.asm
+++ b/data/pokemon/base_stats.asm
@@ -1,5 +1,6 @@
 BaseStats::
 	table_width BASE_DATA_SIZE, BaseStats
+INCLUDE "data/pokemon/base_stats/missingno.asm"
 INCLUDE "data/pokemon/base_stats/bulbasaur.asm"
 INCLUDE "data/pokemon/base_stats/ivysaur.asm"
 INCLUDE "data/pokemon/base_stats/venusaur.asm"
@@ -150,5 +151,4 @@ INCLUDE "data/pokemon/base_stats/dratini.asm"
 INCLUDE "data/pokemon/base_stats/dragonair.asm"
 INCLUDE "data/pokemon/base_stats/dragonite.asm"
 INCLUDE "data/pokemon/base_stats/mewtwo.asm"
-INCLUDE "data/pokemon/base_stats/missingno.asm"
 	assert_table_length NUM_POKEMON ; discount Mew

--- a/data/pokemon/base_stats.asm
+++ b/data/pokemon/base_stats.asm
@@ -150,4 +150,5 @@ INCLUDE "data/pokemon/base_stats/dratini.asm"
 INCLUDE "data/pokemon/base_stats/dragonair.asm"
 INCLUDE "data/pokemon/base_stats/dragonite.asm"
 INCLUDE "data/pokemon/base_stats/mewtwo.asm"
-	assert_table_length NUM_POKEMON - 1 ; discount Mew
+INCLUDE "data/pokemon/base_stats/missingno.asm"
+	assert_table_length NUM_POKEMON ; discount Mew

--- a/data/pokemon/base_stats/missingno.asm
+++ b/data/pokemon/base_stats/missingno.asm
@@ -1,0 +1,26 @@
+	db 0 ; pokedex id
+
+	db 106, 110,  90, 130, 154
+	;   hp  atk  def  spd  spc
+
+	db PSYCHIC_TYPE, PSYCHIC_TYPE ; type
+	db 3 ; catch rate
+	db 220 ; base exp
+
+	INCBIN "gfx/pokemon/front/mewtwo.pic", 0, 1 ; sprite dimensions
+	dw MewtwoPicFront, MewtwoPicBack
+
+	db CONFUSION, DISABLE, SWIFT, PSYCHIC_M ; level 1 learnset
+	db GROWTH_SLOW ; growth rate
+
+	; tm/hm learnset
+	tmhm MEGA_PUNCH,   MEGA_KICK,    TOXIC,        BODY_SLAM,    TAKE_DOWN,    \
+	     DOUBLE_EDGE,  BUBBLEBEAM,   WATER_GUN,    ICE_BEAM,     BLIZZARD,     \
+	     HYPER_BEAM,   SUBMISSION,   COUNTER,      SEISMIC_TOSS, RAGE,         \
+	     SOLARBEAM,    THUNDERBOLT,  THUNDER,      PSYCHIC_M,    TELEPORT,     \
+	     MIMIC,        DOUBLE_TEAM,  REFLECT,      BIDE,         METRONOME,    \
+	     SELFDESTRUCT, FIRE_BLAST,   SKULL_BASH,   REST,         THUNDER_WAVE, \
+	     PSYWAVE,      TRI_ATTACK,   SUBSTITUTE,   STRENGTH,     FLASH
+	; end
+
+	db 0 ; padding

--- a/data/pokemon/base_stats/missingno.asm
+++ b/data/pokemon/base_stats/missingno.asm
@@ -1,17 +1,17 @@
 	db 0 ; pokedex id
 
-	db 106, 110,  90, 130, 154
+	db  33, 136,   0,  29,   6
 	;   hp  atk  def  spd  spc
 
-	db PSYCHIC_TYPE, PSYCHIC_TYPE ; type
-	db 3 ; catch rate
-	db 220 ; base exp
+	db BIRD, NORMAL ; type
+	db  29 ; catch rate
+	db 143 ; base exp
 
 	INCBIN "gfx/pokemon/front/mewtwo.pic", 0, 1 ; sprite dimensions
 	dw MewtwoPicFront, MewtwoPicBack
 
-	db CONFUSION, DISABLE, SWIFT, PSYCHIC_M ; level 1 learnset
-	db GROWTH_SLOW ; growth rate
+	db WATER_GUN, WATER_GUN, SKY_ATTACK, NO_MOVE ; level 1 learnset
+	db 26 ; growth rate
 
 	; tm/hm learnset
 	tmhm MEGA_PUNCH,   MEGA_KICK,    TOXIC,        BODY_SLAM,    TAKE_DOWN,    \

--- a/data/pokemon/base_stats/missingno.asm
+++ b/data/pokemon/base_stats/missingno.asm
@@ -7,8 +7,8 @@
 	db  29 ; catch rate
 	db 143 ; base exp
 
-	INCBIN "gfx/pokemon/front/mewtwo.pic", 0, 1 ; sprite dimensions
-	dw MewtwoPicFront, MewtwoPicBack
+	db $88 ; sprite dimensions
+	dw $190C, MewtwoPicBack
 
 	db WATER_GUN, WATER_GUN, SKY_ATTACK, NO_MOVE ; level 1 learnset
 	db 26 ; growth rate

--- a/home/pokemon.asm
+++ b/home/pokemon.asm
@@ -400,11 +400,6 @@ GetMonHeader::
 	jr z, .mew
 	predef IndexToPokedex   ; convert pokemon ID in [wd11e] to pokedex number
 	ld a, [wd11e]
-	;cp $0
-	;jr z, .findLookupAddress
-	;ld a, [BikerData]
-.findLookupAddress
-	dec a
 	ld bc, BASE_DATA_SIZE
 	ld hl, BaseStats
 	call AddNTimes

--- a/home/pokemon.asm
+++ b/home/pokemon.asm
@@ -400,6 +400,10 @@ GetMonHeader::
 	jr z, .mew
 	predef IndexToPokedex   ; convert pokemon ID in [wd11e] to pokedex number
 	ld a, [wd11e]
+	;cp $0
+	;jr z, .findLookupAddress
+	;ld a, [BikerData]
+.findLookupAddress
 	dec a
 	ld bc, BASE_DATA_SIZE
 	ld hl, BaseStats


### PR DESCRIPTION
Missingno's base stats come from reading other data as a Pokemon. Other changes in this ROM hack turns this glitch into a crash. Now Missingno has base data mapped to a base address for Pokedex entry 0. To load this, finding the base stats base address uses the Pokedex number instead of one less than the Pokedex number